### PR TITLE
Move 'view details' link into it's own container that can wrap at mobile

### DIFF
--- a/app/styles/_kve.less
+++ b/app/styles/_kve.less
@@ -118,6 +118,7 @@
   .key-value-editor-entry,
   .environment-from-entry {
     display: table;
+    margin-bottom: 15px;
     padding-right: (@as-sortable-item-button-width * 2);
     position: relative;
     table-layout: fixed;
@@ -127,11 +128,12 @@
         float: left;
         padding-right: 5px;
         position: relative;
-        width: 50%;
+        width: auto;
       }
     }
     .environment-from-input {
       float: left;
+      margin-bottom: 0;
       padding-right: 5px;
       width: 100%;
       @media(min-width: @screen-md-min) {
@@ -142,6 +144,13 @@
         float: left;
         width: 100%;
       }
+    }
+  }
+  .environment-from-entry {
+    .environment-from-view-details {
+      float: left;
+      line-height: 1;
+      padding: 6px 0 0;
     }
   }
 
@@ -163,6 +172,7 @@
 .key-value-editor .key-value-editor-input,
 .key-value-editor-header {
   float: left;
+  margin-bottom: 0;
   padding-right: 5px;
   width: 50%;
 }

--- a/app/views/directives/edit-environment-from.html
+++ b/app/views/directives/edit-environment-from.html
@@ -67,11 +67,12 @@
           role="button"
           aria-label="Delete row"
           ng-click="$ctrl.deleteEntry($index, 1)"></a>
+      </div>
+      <div class="environment-from-view-details">
         <a
           ng-if="entry.selectedEnvFrom"
           href=""
-          ng-click="$ctrl.viewOverlayPanel(entry.selectedEnvFrom)"
-          class="pficon">View Details</a>
+          ng-click="$ctrl.viewOverlayPanel(entry.selectedEnvFrom)">View Details</a>
       </div>
     </div>
 


### PR DESCRIPTION
Some adjustments needed for vertical alignment.
Reference https://github.com/openshift/origin-web-console/issues/2182

Desktop
<img width="628" alt="screen shot 2017-10-09 at 2 18 07 pm" src="https://user-images.githubusercontent.com/1874151/31352457-de6150aa-acfc-11e7-8afe-88f4a8f5ff86.png">

Mobile
<img width="424" alt="screen shot 2017-10-09 at 2 17 50 pm" src="https://user-images.githubusercontent.com/1874151/31352463-e65bd05a-acfc-11e7-93da-b3085a031578.png">


